### PR TITLE
Lowercase lib names in Windows link attributes

### DIFF
--- a/src/platform/win32/ffi.rs
+++ b/src/platform/win32/ffi.rs
@@ -313,7 +313,7 @@ pub struct WINDOWPOS {
 }
 
 // Static Linked Functions
-#[link(name = "Kernel32")]
+#[link(name = "kernel32")]
 extern "system" {
     pub fn GetLastError() -> DWORD;
     pub fn SetLastError(dwErrCode: DWORD);
@@ -331,7 +331,7 @@ extern "system" {
     pub fn LoadLibraryExA(lpLibFileName: *const CHAR, hFile: HANDLE, dwFlags: DWORD) -> HMODULE;
     pub fn VerSetConditionMask(ConditionMask: c_ulonglong, TypeMask: DWORD, Condition: BYTE) -> c_ulonglong;
 }
-#[link(name = "User32")]
+#[link(name = "user32")]
 extern "system" {
     // Window class management
     pub fn GetClassInfoExW(hinst: HINSTANCE, lpszClass: *const WCHAR, lpwcx: *mut WNDCLASSEXW) -> BOOL;


### PR DESCRIPTION
Cross-building for Windows on (for example) Linux exposes some fun case-sensitivity issues, since mingw libraries are in all lowercase. This just changes title-case library names to lowercase, and shouldn't affect native Windows builds at all (I hope).